### PR TITLE
Code re-organization

### DIFF
--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -11,7 +11,9 @@ defmodule Bugsnag do
 
     # Update Application config with evaluated configuration
     # It's needed for use in Bugsnag.Payload
-    Application.put_all_env(bugsnag: config)
+    Enum.each(config, fn {k, v} ->
+      Application.put_env(:bugsnag, k, v)
+    end)
 
     if is_nil(config[:api_key]) and reported_stage?() do
       Logger.warn("Bugsnag api_key is not configured, errors will not be reported")

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -1,6 +1,5 @@
 defmodule Bugsnag do
   use Application
-  import Supervisor.Spec
   require Logger
 
   alias Bugsnag.Payload
@@ -33,11 +32,10 @@ defmodule Bugsnag do
     end
 
     children = [
-      supervisor(Task.Supervisor, [[name: Bugsnag.TaskSupervisor]])
+      {Task.Supervisor, name: Bugsnag.TaskSupervisor}
     ]
 
-    opts = [strategy: :one_for_one, name: Bugsnag.Supervisor]
-    Supervisor.start_link(children, opts)
+    Supervisor.start_link(children, strategy: :one_for_one, name: Bugsnag.Supervisor)
   end
 
   @doc """

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -37,9 +37,12 @@ defmodule Bugsnag do
   Report the exception without waiting for the result of the Bugsnag API call.
   (I.e. this might fail silently)
   """
-  defdelegate report(expection, opts \\ []), to: Bugsnag.Reporter
+
+  @spec report(exception :: term(), opts :: list()) :: :ok | {:error, :cannot_start_task}
+  defdelegate report(exception, opts \\ []), to: Bugsnag.Reporter
 
   @doc "Report the exception and wait for the result. Returns `:ok` or `{:error, reason}`."
+  @spec sync_report(exception :: term(), opts :: list()) :: :ok | {:error, reason :: term()}
   defdelegate sync_report(exception, opts \\ []), to: Bugsnag.Reporter
 
   defp reported_stage?() do

--- a/lib/bugsnag/reporter.ex
+++ b/lib/bugsnag/reporter.ex
@@ -1,0 +1,88 @@
+defmodule Bugsnag.Reporter do
+  @moduledoc false
+
+  alias Bugsnag.Payload
+  require Logger
+
+  @default_notify_url "https://notify.bugsnag.com"
+  @request_headers [{"Content-Type", "application/json"}]
+
+  @doc """
+  Report the exception without waiting for the result of the Bugsnag API call
+  """
+  def report(exception, options \\ []) do
+    Task.Supervisor.start_child(
+      Bugsnag.TaskSupervisor,
+      __MODULE__,
+      :sync_report,
+      [
+        exception,
+        add_stacktrace(options)
+      ],
+      restart: :transient
+    )
+  end
+
+  @doc "Report the exception and wait for the result. Returns `ok` or `{:error, reason}`."
+  def sync_report(exception, options \\ []) do
+    stacktrace = options[:stacktrace] || System.stacktrace()
+
+    if should_notify(exception, stacktrace) do
+      if Application.get_env(:bugsnag, :api_key) do
+        exception
+        |> Payload.new(stacktrace, options)
+        |> Payload.encode()
+        |> send_notification
+        |> case do
+          {:ok, %{status_code: 200}} -> :ok
+          {:ok, %{status_code: other}} -> {:error, "status_#{other}"}
+          {:error, %{reason: reason}} -> {:error, reason}
+          _ -> {:error, :unknown}
+        end
+      else
+        Logger.warn("Bugsnag api_key is not configured, error not reported")
+        {:error, %{reason: "API key is not configured"}}
+      end
+    else
+      {:ok, :not_sent}
+    end
+  end
+
+  defp send_notification(body) do
+    HTTPoison.post(notify_url(), body, @request_headers)
+  end
+
+  defp notify_url do
+    Application.get_env(:bugsnag, :endpoint_url, @default_notify_url)
+  end
+
+  def should_notify(exception, stacktrace) do
+    reported_stage?() && test_filter(exception_filter(), exception, stacktrace)
+  end
+
+  defp reported_stage?() do
+    release_stage = Application.get_env(:bugsnag, :release_stage)
+    notify_stages = Application.get_env(:bugsnag, :notify_release_stages)
+    release_stage && is_list(notify_stages) && Enum.member?(notify_stages, release_stage)
+  end
+
+  defp exception_filter() do
+    Application.get_env(:bugsnag, :exception_filter)
+  end
+
+  defp test_filter(nil, _, _), do: true
+
+  defp test_filter(module, exception, stacktrace) do
+    try do
+      module.should_notify(exception, stacktrace)
+    rescue
+      _ ->
+        # Swallowing error in order to avoid exception loops
+        true
+    end
+  end
+
+  defp add_stacktrace(options) do
+    if options[:stacktrace], do: options, else: put_in(options[:stacktrace], System.stacktrace())
+  end
+end


### PR DESCRIPTION
- [x] removes deprecated `Supervisor.Spec` usage
- [x] move reporting functions to `Bugsnag.Reporter` and add defdelegates
- [x] add typespecs
- [x] restrict error return of `Bugsnag.report/2`