### PR TITLE
Ensure tasks under Bugsnag.TaskSupervisor don't spill into other tests

### DIFF
--- a/test/bugsnag_test.exs
+++ b/test/bugsnag_test.exs
@@ -15,6 +15,18 @@ defmodule BugsnagTest do
     def should_notify(_e, _s), do: raise("boom")
   end
 
+  setup do
+    on_exit(fn ->
+      Bugsnag.TaskSupervisor
+      |> Task.Supervisor.children()
+      |> Enum.each(fn pending_task_pid ->
+        Task.Supervisor.terminate_child(Bugsnag.TaskSupervisor, pending_task_pid)
+      end)
+    end)
+
+    :ok
+  end
+
   test "it doesn't raise errors if you report garbage" do
     capture_log(fn ->
       Bugsnag.report(Enum, %{ignore: :this_error_in_test})


### PR DESCRIPTION
This PR fixes the issue of tests failing intermittently (reported in https://github.com/bugsnag-elixir/bugsnag-elixir/issues/104).

It turns out a test in `BugsnagTest` was causing a task to be started by the reporter, under `Bugsnag.TaskSupervisor`, but it wasn't waiting for the task to finish or checking anything in it.

This was cauing tests in `Bugsnag.LoggerTest` to fail when the problematic test was executed before them. The dangling task was getting executed while the logger tests were running, causing `HTTPMock` to be called twice which crashes the Mox process and every other test that depend on it.

This PR adds a snippet that is executed after each test in `BugsnagTest` to terminate possible dangling tasks in the supervisor and so prevent this issue from occurring again.