### PR TITLE
Add option to set error class instead of infering from the exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ The following options allow adding more data to the report:
 * `os_version` — Sets the reported OS version of the error
 * `stacktrace` — Allows passing in a stack trace, e.g. from `__STACKTRACE__`
 * `metadata` - Map of arbitrary metadata to include with the report
+* `error_class` - Allows passing in the error type instead of infering from the error struct
 
 [See the Bugsnag docs][2] for more information on these fields.
 

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -55,7 +55,7 @@ defmodule Bugsnag.Payload do
   defp add_exception(event, exception, stacktrace, options) do
     Map.put(event, :exceptions, [
       %{
-        errorClass: exception.__struct__,
+        errorClass: Keyword.get(options, :error_class, exception.__struct__),
         message: sanitize(Exception.message(exception)),
         stacktrace: format_stacktrace(stacktrace, options)
       }

--- a/test/bugsnag/payload_test.exs
+++ b/test/bugsnag/payload_test.exs
@@ -39,6 +39,16 @@ defmodule Bugsnag.PayloadTest do
     refute Map.has_key?(get_event(), :metaData)
   end
 
+  test "it adds error_class when given" do
+    error_class = CustomError
+    assert error_class == get_exception(error_class: error_class).errorClass
+  end
+
+  test "errorClass defaults to the exception struct module" do
+    [exception, _] = get_problem()
+    assert exception.__struct__ == get_exception().errorClass
+  end
+
   test "it generates correct stacktraces" do
     {exception, stacktrace} =
       try do


### PR DESCRIPTION
This PR addresses https://github.com/bugsnag-elixir/bugsnag-elixir/issues/97 by introducing a new option, `error_class`, which can be passed to [`Bugsnag.Reporter.report/2`](https://github.com/bugsnag-elixir/bugsnag-elixir/blob/577107f1847c9bfce7ec657952defbb4a311013e/lib/bugsnag/reporter.ex#L11-L32) and [`Bugsnag.Reporter.sync_report/2`](https://github.com/bugsnag-elixir/bugsnag-elixir/blob/577107f1847c9bfce7ec657952defbb4a311013e/lib/bugsnag/reporter.ex#L34-L56) to specify the type of the error being reported instead of determining the error class using the module of the exception struct.

The default behavior is still the same, if the option is not passed the error class will be the module of the given exception struct (i.e.
`exception.__struct__`).