### PR TITLE
RemoveStacktraceDeprecations

### DIFF
--- a/lib/bugsnag/reporter.ex
+++ b/lib/bugsnag/reporter.ex
@@ -32,7 +32,7 @@ defmodule Bugsnag.Reporter do
   end
 
   def sync_report(exception, options \\ []) do
-    stacktrace = options[:stacktrace] || System.stacktrace()
+    stacktrace = options[:stacktrace] || __STACKTRACE__
 
     if should_notify(exception, stacktrace) do
       if Application.get_env(:bugsnag, :api_key) do
@@ -86,6 +86,6 @@ defmodule Bugsnag.Reporter do
   end
 
   defp add_stacktrace(options) do
-    if options[:stacktrace], do: options, else: put_in(options[:stacktrace], System.stacktrace())
+    if options[:stacktrace], do: options, else: put_in(options[:stacktrace], __STACKTRACE__)
   end
 end

--- a/test/bugsnag/payload_sanitizer_test.exs
+++ b/test/bugsnag/payload_sanitizer_test.exs
@@ -22,7 +22,7 @@ defmodule Bugsnag.PayloadSanitizerTest do
       try do
         raise "123fail123"
       rescue
-        exception -> [exception, System.stacktrace(), []]
+        exception -> [exception, __STACKTRACE__, []]
       end
     end
 
@@ -81,12 +81,12 @@ defmodule Bugsnag.PayloadSanitizerTest do
   def get_problem(args, options \\ []) do
     Module.concat(Elixir, "Harbour").cats(args)
   rescue
-    exception -> [exception, System.stacktrace(), options]
+    exception -> [exception, __STACKTRACE__, options]
   end
 
   def get_problem_with_error_message(msg) do
     raise msg
   rescue
-    exception -> [exception, System.stacktrace(), []]
+    exception -> [exception, __STACKTRACE__, []]
   end
 end

--- a/test/bugsnag/payload_test.exs
+++ b/test/bugsnag/payload_test.exs
@@ -8,7 +8,7 @@ defmodule Bugsnag.PayloadTest do
       # You've been warned!
       raise "an error occurred"
     rescue
-      exception -> [exception, System.stacktrace()]
+      exception -> [exception, __STACKTRACE__]
     end
   end
 
@@ -44,7 +44,7 @@ defmodule Bugsnag.PayloadTest do
       try do
         Enum.join(3, 'million')
       rescue
-        exception -> {exception, System.stacktrace()}
+        exception -> {exception, __STACKTRACE__}
       end
 
     %{events: [%{exceptions: [%{stacktrace: stacktrace}]}]} =
@@ -78,7 +78,7 @@ defmodule Bugsnag.PayloadTest do
       try do
         Module.concat(Elixir, "Movies").watch(:thor, 3, "ragnarok\n")
       rescue
-        exception -> {exception, System.stacktrace()}
+        exception -> {exception, __STACKTRACE__}
       end
 
     %{events: [%{exceptions: [%{stacktrace: stacktrace}]}]} =
@@ -96,7 +96,7 @@ defmodule Bugsnag.PayloadTest do
       try do
         Module.concat(Elixir, "Bugsnag.Payload").non_existent_func()
       rescue
-        exception -> {exception, System.stacktrace()}
+        exception -> {exception, __STACKTRACE__}
       end
 
     %{events: [%{exceptions: [%{stacktrace: stacktrace}]}]} =


### PR DESCRIPTION
Replacing all instances of System.stacktrace() with __STACKTRACE__ as per compiler warnings in Elixir 1.11