### PR TITLE
Remove deprecated system stacktrace warnings in tests

### DIFF
--- a/test/bugsnag/payload_sanitizer_test.exs
+++ b/test/bugsnag/payload_sanitizer_test.exs
@@ -22,7 +22,7 @@ defmodule Bugsnag.PayloadSanitizerTest do
       try do
         raise "123fail123"
       rescue
-        exception -> [exception, System.stacktrace(), []]
+        exception -> [exception, __STACKTRACE__, []]
       end
     end
 
@@ -81,12 +81,12 @@ defmodule Bugsnag.PayloadSanitizerTest do
   def get_problem(args, options \\ []) do
     Module.concat(Elixir, "Harbour").cats(args)
   rescue
-    exception -> [exception, System.stacktrace(), options]
+    exception -> [exception, __STACKTRACE__, options]
   end
 
   def get_problem_with_error_message(msg) do
     raise msg
   rescue
-    exception -> [exception, System.stacktrace(), []]
+    exception -> [exception, __STACKTRACE__, []]
   end
 end

--- a/test/bugsnag/payload_test.exs
+++ b/test/bugsnag/payload_test.exs
@@ -8,7 +8,7 @@ defmodule Bugsnag.PayloadTest do
       # You've been warned!
       raise "an error occurred"
     rescue
-      exception -> [exception, System.stacktrace()]
+      exception -> [exception, __STACKTRACE__]
     end
   end
 
@@ -54,7 +54,7 @@ defmodule Bugsnag.PayloadTest do
       try do
         Enum.join(3, 'million')
       rescue
-        exception -> {exception, System.stacktrace()}
+        exception -> {exception, __STACKTRACE__}
       end
 
     %{events: [%{exceptions: [%{stacktrace: stacktrace}]}]} =
@@ -88,7 +88,7 @@ defmodule Bugsnag.PayloadTest do
       try do
         Module.concat(Elixir, "Movies").watch(:thor, 3, "ragnarok\n")
       rescue
-        exception -> {exception, System.stacktrace()}
+        exception -> {exception, __STACKTRACE__}
       end
 
     %{events: [%{exceptions: [%{stacktrace: stacktrace}]}]} =
@@ -106,7 +106,7 @@ defmodule Bugsnag.PayloadTest do
       try do
         Module.concat(Elixir, "Bugsnag.Payload").non_existent_func()
       rescue
-        exception -> {exception, System.stacktrace()}
+        exception -> {exception, __STACKTRACE__}
       end
 
     %{events: [%{exceptions: [%{stacktrace: stacktrace}]}]} =


### PR DESCRIPTION
Since Bugsnag supports Elixir 1.8 and above, it's time to replace the deprecated System.stacktrace/1 since Elixir 1.11 with pseudo-variable __STACKTRACE__.